### PR TITLE
add get method to history breadcrumbs

### DIFF
--- a/scripts/buildfire.js
+++ b/scripts/buildfire.js
@@ -898,9 +898,13 @@ var buildfire = {
         triggerOnPop: function (obj) {
             buildfire.eventManager.trigger('historyOnPop', obj);
         },
-        pop: function () {
+        pop: function (callback) {
             var p = new Packet(null, 'history.pop');
-            buildfire._sendPacket(p);
+            buildfire._sendPacket(p, callback);
+        },
+        get: function (callback) {
+            var p = new Packet(null, 'history.get');
+            buildfire._sendPacket(p, callback);
         }
     }
     /// ref: https://github.com/BuildFire/sdk/wiki/How-to-use-Messaging-to-sync-your-Control-to-Widget


### PR DESCRIPTION
added get method to history breadcrumbs in buildfire.js to enable plugin developers to fetch current breadcrumbs stack.