### PR TITLE
GridLayoutLauncher: Logo image does not display

### DIFF
--- a/scripts/buildfire.js
+++ b/scripts/buildfire.js
@@ -861,9 +861,9 @@ var buildfire = {
             if (options.height == 'full') options.height = window.innerHeight;
 
             if (options.width && !options.height)
-                return root + "width/" + (options.width * ratio) + "/" + url;
+                return root + "width/" + Math.floor(options.width * ratio) + "/" + url;
             else if (!options.width && options.height)
-                return root + "height/" + (options.height * ratio) + "/" + url;
+                return root + "height/" + Math.floor(options.height * ratio) + "/" + url;
             else if (options.width && options.height)
                 return root + "resizenp/" + Math.floor(options.width * ratio) + "x" + Math.floor(options.height * ratio) + "/" + url;
             else


### PR DESCRIPTION
Logo image does not display since the url sent to cloudimage have float number. This was fixed by using Math.floor.