### PR TITLE
Set devicePixelRatio to at least 1 to prevent zoom issue on carousel.

### DIFF
--- a/scripts/buildfire.js
+++ b/scripts/buildfire.js
@@ -1096,6 +1096,12 @@ var buildfire = {
         , resizeImage: function (url, options) {
 
             var ratio = options.disablePixelRation?1:window.devicePixelRatio;
+
+			// Don't pass any value under 1
+			if(ratio < 1){
+				var ratio = '1';
+			}
+			
             if (!options)
                 options = {width: window.innerWidth};
             else if (typeof(options) != "object")

--- a/scripts/buildfire.js
+++ b/scripts/buildfire.js
@@ -1099,7 +1099,7 @@ var buildfire = {
 
 			// Don't pass any value under 1
 			if(ratio < 1){
-				var ratio = '1';
+				var ratio = 1;
 			}
 			
             if (!options)


### PR DESCRIPTION
Set devicePixelRatio to at least 1 to prevent zoom issue on carousel.