### PR TITLE
**SOF** Buildfire - Issue Loading Plugin in Previewer

### DIFF
--- a/pluginTester/scripts/loadScripts.js
+++ b/pluginTester/scripts/loadScripts.js
@@ -28,7 +28,7 @@ function _ScriptLoader(){
         , this.domain + "app/scripts/framework/pluginAPI/authAPI.js"
         , this.domain + "scripts/framework/openDialogCtrl.js"
         , this.domain + "app/scripts/framework/modalCtrl.js"
-        , this.domain + "pages/plugins/addPlugin/addPageDialogCtrl.js"
+        , this.domain + "pages/plugins/addPlugin/modals/addPageCtrl.js"
         , this.domain + "app/scripts/framework/pluginAPI/localNotificationsAPI.js"
         , this.domain + "app/scripts/framework/pluginAPI/localStorageAPI.js"
     ];


### PR DESCRIPTION
Fix 404 when getting "**pages/plugins/addPlugin/addPageDialogCtrl.js**" . This was moved to "**pages/plugins/addPlugin/modals/addPageCtrl.js**" in "**Web**" repo.