### PR TITLE
Make the SDK work with plugins made with Webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,189 @@
+{
+  "name": "BuildFireSDK",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.0.tgz",
+      "integrity": "sha1-NgTHZVhsO5z3h3tpN829RYf5R9w=",
+      "dev": true,
+      "requires": {
+        "mime": "1.2.11",
+        "negotiator": "0.3.0"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
+      "integrity": "sha1-kc2ZfMUftkFZVzjGnNoCAyj1D/k=",
+      "dev": true
+    },
+    "debug": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+      "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+      "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.0.0.tgz",
+      "integrity": "sha1-J03IKTPJ9XTMOKDOXqgXK+nGsJQ=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.0.0",
+        "buffer-crc32": "0.2.1",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.3",
+        "debug": "0.8.1",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "merge-descriptors": "0.0.2",
+        "methods": "0.1.0",
+        "parseurl": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "qs": "0.6.6",
+        "range-parser": "1.0.0",
+        "send": "0.2.0",
+        "serve-static": "1.0.1",
+        "type-is": "1.0.0",
+        "utils-merge": "1.0.0"
+      }
+    },
+    "fresh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+      "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+      "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc=",
+      "dev": true
+    },
+    "methods": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
+      "integrity": "sha1-M11Cnu/SG3us8unJIqjSvRSjDk8=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+      "integrity": "sha1-cG1pLv7d9XTVfqn7GriaT6fuj2A=",
+      "dev": true
+    },
+    "parseurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+      "integrity": "sha1-Llfc5u/dN8NRhwEDCUTCK/OIt7Q=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
+      "integrity": "sha1-mysVH5zDAYye6lDKlXKeBXgXErQ=",
+      "dev": true
+    },
+    "qs": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+      "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A=",
+      "dev": true
+    },
+    "send": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.2.0.tgz",
+      "integrity": "sha1-Bnq/Rc/4v/spy9t0OXJbMjiKLFg=",
+      "dev": true,
+      "requires": {
+        "debug": "0.8.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "range-parser": "1.0.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.1.tgz",
+      "integrity": "sha1-ENy/1Es+ApGhMfyatKslqfWnikI=",
+      "dev": true,
+      "requires": {
+        "send": "0.1.4"
+      },
+      "dependencies": {
+        "fresh": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+          "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc=",
+          "dev": true
+        },
+        "range-parser": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+          "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs=",
+          "dev": true
+        },
+        "send": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+          "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+          "dev": true,
+          "requires": {
+            "debug": "0.8.1",
+            "fresh": "0.2.0",
+            "mime": "1.2.11",
+            "range-parser": "0.0.4"
+          }
+        }
+      }
+    },
+    "type-is": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.0.0.tgz",
+      "integrity": "sha1-T/Qk6XNJoe4ZELS/xIhZXs3EQ/w=",
+      "dev": true,
+      "requires": {
+        "mime": "1.2.11"
+      }
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "body-parser": "1.11.0",
     "chai": "^3.3.0",
-    "express": "4.0.0",
+    "express": "^4.0.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-uglify": "^3.0.0",

--- a/pluginTester/app.js
+++ b/pluginTester/app.js
@@ -28,7 +28,9 @@ $app.config(['$routeProvider', '$sceDelegateProvider', function ($routeProvider,
 		// Allow same origin resource loads.
 		'self',
 		// Allow loading from our assets domain.  Notice the difference between * and **.
-		window.siteConfig.endPoints.pluginHost + '/**'
+		window.siteConfig.endPoints.pluginHost + '/**',
+		// Allow webpack plugins
+		'http://127.0.0.1:8080/**'
 	]);
 
 }]);

--- a/pluginTester/pages/controllers/shellCtrl.js
+++ b/pluginTester/pages/controllers/shellCtrl.js
@@ -149,7 +149,7 @@ $app.controller('shellCtrl', ['$rootScope', '$scope', '$routeParams', '$sce', '$
 
             $scope.currentControl = $scope.pluginConfig.webpack
                 ? 'http://127.0.0.1:8080/control/' + section + '/index.html?fid=control'
-                : '../plugins' + pluginFolder + '/control/' + section + '/index.html?fid=control';
+                : '../plugins/' + pluginFolder + '/control/' + section + '/index.html?fid=control';
 
             var element = document.querySelector('.active');
             if (element)element.className = '';

--- a/scripts/buildfire.js
+++ b/scripts/buildfire.js
@@ -474,7 +474,7 @@ var buildfire = {
         }
         , attachCSSFiles: function () {
             var files = ['styles/bootstrap.css'], base = '';
-            if (window.location.pathname.indexOf('/control/') > 0) {
+            if (window.location.pathname.indexOf('/control/') >= 0) {
                 files.push('styles/siteStyle.css') &&
                 files.push('styles/pluginScreen.css');
             }
@@ -865,7 +865,7 @@ var buildfire = {
                 if (callback) callback(err, result);
             });
         }
-        /// ref: 
+        /// ref:
         , insert: function (obj, tag, userToken, checkDuplicate, callback) {
 
             var userTokenType = typeof (userToken);
@@ -904,7 +904,7 @@ var buildfire = {
                 callback(err, result);
             });
         }
-        /// ref: 
+        /// ref:
         , bulkInsert: function (arrayObj, tag, userToken, callback) {
 
             if (arrayObj.constructor !== Array) {
@@ -933,7 +933,7 @@ var buildfire = {
                 callback(err, result);
             });
         }
-        ///  
+        ///
         , update: function (id, obj, tag, userToken, callback) {
             var userTokenType = typeof (userToken);
             if (userTokenType == "undefined")
@@ -980,7 +980,7 @@ var buildfire = {
                 if (callback) callback(err, result);
             });
         }
-        /// ref 
+        /// ref
         , delete: function (id, tag, userToken, callback) {
 
             var userTokenType = typeof (userToken);
@@ -1004,7 +1004,7 @@ var buildfire = {
                 if (callback) callback(err, result);
             });
         }
-        /// 
+        ///
         , search: function (options, tag, callback) {
 
             var tagType = typeof (tag);
@@ -1024,21 +1024,21 @@ var buildfire = {
                 callback(err, result);
             });
         }
-        /// ref: 
+        /// ref:
         , onUpdate: function (callback, allowMultipleHandlers) {
             return buildfire.eventManager.add('userDataOnUpdate', callback, allowMultipleHandlers);
         }
         , triggerOnUpdate: function (obj) {
             buildfire.eventManager.trigger('userDataOnUpdate', obj);
         }
-        /// ref:  
+        /// ref:
         , onRefresh: function (callback, allowMultipleHandlers) {
             return buildfire.eventManager.add('userDataOnRefresh', callback, allowMultipleHandlers);
         }
         , triggerOnRefresh: function (obj) {
             buildfire.eventManager.trigger('userDataOnRefresh', obj);
         }
-        /// ref:  
+        /// ref:
         , disableRefresh: function () {
             var p = new Packet(null, "userData.disableRefresh");
             buildfire._sendPacket(p);
@@ -1434,7 +1434,7 @@ var buildfire = {
 
                 if (options.width == 'full') options.width = window.innerWidth;
                 if (options.height == 'full') options.height = window.innerHeight;
-                
+
                 var localURL = buildfire.imageLib.local.toLocalPath(url);
                 if (localURL) {
                     var img = new Image();
@@ -1475,7 +1475,7 @@ var buildfire = {
                         dim.height     *= ratio;
                         options.width  *= ratio;
                         options.height *= ratio;
-                        
+
                         canvas.width = options.width;
                         canvas.height = options.height;
                         ctx.drawImage(img, offset.x, offset.y, dim.width, dim.height);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,7 @@
+var express = require('express');
+var app = express();
+
+app.use(express.static(__dirname));
+app.listen(3000, function() {
+  console.log('  \x1b[32mBuildFireSDK running on [::]:3000');
+});


### PR DESCRIPTION
This PR implements webpack plugin support.

Any developer that creates a plugin using the provided `plugin-template-webpack` or `plugin-template-react` templates will be able to preview his plugin since now we detect if the plugin.json contains `webpack: portNumber` and as a result, iframe the webpack-dev-server instead.