### PR TITLE
Corrected error causing css file injection to fail

### DIFF
--- a/scripts/buildfire.js
+++ b/scripts/buildfire.js
@@ -1866,7 +1866,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         else {
             if (context && context.debugTag)
                 buildfire.logger.attachRemoteLogger(context.debugTag);
-            if (window.location.pathname.indexOf('/widget/') > 0) {
+            if (window.location.pathname.indexOf('/widget/') > -1) {
                 var disableTheme = (buildfire.options && buildfire.options.disableTheme) ? buildfire.options.disableTheme : false;
 
                 if(!disableTheme) {


### PR DESCRIPTION
`if (window.location.pathname.indexOf('/widget/') > 0)` evaluates to `false` when using React Template